### PR TITLE
feat - add mood radio button selection and their event listener

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,8 @@
             </article>
             <aside class="main__entries">
             </aside>
+            <aside class="filters">
+            </aside>
         </main>        
         <footer>
             <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Perspiciatis incidunt libero error non delectus quasi sed, laboriosam in placeat aut, ducimus eaque dolore. Consequatur aliquam odit aperiam dolore voluptates excepturi.</p>

--- a/scripts/filter/FilterBar.js
+++ b/scripts/filter/FilterBar.js
@@ -1,0 +1,5 @@
+import { moodFilter } from "./moodFilter.js"
+
+const contentTarget = document.querySelector(".filters")
+
+export const FilterBar = () => contentTarget.innerHTML = `${moodFilter()}`

--- a/scripts/filter/moodFilter.js
+++ b/scripts/filter/moodFilter.js
@@ -1,0 +1,47 @@
+/*
+ Get a copy of moods.
+
+*/
+const eventHub = document.querySelector("main")
+
+const moods = [
+  {
+    id: 1,
+    label: "happy"
+  },
+  {
+    id: 2,
+    label: "sad"
+  },
+  {
+    id: 3,
+    label: "cold"
+  }
+]
+export const moodFilter = () => {
+ const _moods = moods.map((mood) => {
+  return `
+    <input type="radio" name="moodFilter" id="${ mood.id }" value="${ mood.id }" />
+    <label for="${ mood.id }" >${ mood.label }</label>
+  `
+ }).join("") // moods.map
+ 
+ return `
+   <fieldset class="fieldset">
+    <legend>Filter Entries by Mood</legend>
+    ${_moods}
+   </fieldset>
+ `
+}
+
+eventHub.addEventListener("click", clickEvent => {
+  if(clickEvent.target.name === "moodFilter") {
+    const moodId = parseInt(clickEvent.target.id)
+    const customEvent = new CustomEvent("moodSelected", {
+      detail: {
+        moodId: moodId
+      }
+    }) // CustomEvent
+    eventHub.dispatchEvent(customEvent)
+  } // if
+}) // eventHub - click

--- a/scripts/journalEntries/JournalDataProvider.js
+++ b/scripts/journalEntries/JournalDataProvider.js
@@ -1,11 +1,6 @@
 let journal = []
 const eventHub = document.querySelector("main")
 
-/*
-Hardcoded data moved to entires.json for api use.
-*/
-
-
 export const useJournalEntries = () => journal.sort(_byDate)
 const journalStateChanged = new CustomEvent("journalStateChanged")
 const dispatchStateChangeEvent = () => eventHub.dispatchEvent(journalStateChanged)

--- a/scripts/journalEntries/JournalEntryList.js
+++ b/scripts/journalEntries/JournalEntryList.js
@@ -25,3 +25,7 @@ export const EntryListComponent = () => {
 eventHub.addEventListener("journalStateChanged", customEvent => {
  getEntries().then(() => EntryListComponent())
 })
+
+eventHub.addEventListener("moodSelected", selectEvent => {
+
+}) // eventHub - moodSelected

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,6 +1,10 @@
 import { getEntries } from "./journalEntries/JournalDataProvider.js";
 import { EntryListComponent } from "./journalEntries/JournalEntryList.js"
 import { JournalFormComponent } from "./journalEntries/JournalFormComponent.js"
+import { FilterBar } from "./filter/FilterBar.js"
 
-JournalFormComponent()
-getEntries().then(() => EntryListComponent())
+getEntries().then(() => {
+ JournalFormComponent()
+ EntryListComponent()
+ FilterBar()
+})

--- a/styles/main.css
+++ b/styles/main.css
@@ -192,3 +192,7 @@ footer p {
   margin: 0 auto;
   border-radius: 10px;
 }
+
+.filters {
+  border: 1px solid red;
+}


### PR DESCRIPTION
# Description
Add radio buttons to filter notes by moon. If no mood is selected or the `All` option, all notes are displayed.

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# Testing Instructions

`git fetch --all`
`git checkout filter-by-mood`
`serve`

In another terminal where you db is located.

`json-server -p 8088 -w entires.json`

If filter/notes available, select radio button to filter entries by mood.

If no notes are available, create notes and select radio button to filter by mood.


# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings or errors
- [X] I have added test instructions that prove my fix is effective or that my feature works