### PR TITLE
feat - radio buttons filter notes by mood

### DIFF
--- a/api/entries.json
+++ b/api/entries.json
@@ -3,10 +3,122 @@
     {
       "date": "2/14/2021, 09:36 PM",
       "concept": "tacos",
-      "moodId": 17,
+      "moodId": 1,
       "instructorId": 4,
       "entry": "eat tacos",
       "id": 1
+    },
+    {
+      "date": "2/15/2021, 05:20 PM",
+      "concept": "refactoring",
+      "moodId": 2,
+      "instructorId": 5,
+      "entry": "refacotring code to take input",
+      "id": 2
+    },
+    {
+      "date": "2/15/2021, 05:23 PM",
+      "concept": "snacks time",
+      "moodId": 3,
+      "instructorId": 3,
+      "entry": "snacks for braks",
+      "id": 3
+    },
+    {
+      "date": "2/15/2021, 05:24 PM",
+      "concept": "refactoring snacks",
+      "moodId": 1,
+      "instructorId": 3,
+      "entry": "refacotring code to take input",
+      "id": 4
+    },
+    {
+      "date": "2/15/2021, 05:25 PM",
+      "concept": "snacks",
+      "moodId": 2,
+      "instructorId": 1,
+      "entry": "snacks",
+      "id": 5
+    },
+    {
+      "date": "2/15/2021, 05:26 PM",
+      "concept": "refactoring",
+      "moodId": 3,
+      "instructorId": 5,
+      "entry": "refacotring code to take input",
+      "id": 6
+    },
+    {
+      "date": "2/15/2021, 05:27 PM",
+      "concept": "snacks",
+      "moodId": 1,
+      "instructorId": 1,
+      "entry": "snacks",
+      "id": 7
+    },
+    {
+      "date": "2/15/2021, 05:28 PM",
+      "concept": "refactoring",
+      "moodId": 2,
+      "instructorId": 5,
+      "entry": "refacotring code to take input",
+      "id": 8
+    },
+    {
+      "date": "2/15/2021, 05:29 PM",
+      "concept": "snacks",
+      "moodId": 3,
+      "instructorId": 1,
+      "entry": "snacks",
+      "id": 9
+    },
+    {
+      "date": "2/15/2021, 05:40 PM",
+      "concept": "refactoring",
+      "moodId": 5,
+      "instructorId": 5,
+      "entry": "refacotring code to take input",
+      "id": 10
+    },
+    {
+      "date": "2/15/2021, 05:43 PM",
+      "concept": "snacks",
+      "moodId": 8,
+      "instructorId": 1,
+      "entry": "snacks",
+      "id": 11
+    },
+    {
+      "date": "2/15/2021, 05:44 PM",
+      "concept": "refactoring",
+      "moodId": 5,
+      "instructorId": 5,
+      "entry": "refacotring code to take input",
+      "id": 12
+    },
+    {
+      "date": "2/15/2021, 05:41 PM",
+      "concept": "staechanged",
+      "moodId": 12,
+      "instructorId": 1,
+      "entry": "journal sttate change error",
+      "id": 13
+    },
+    {
+      "date": "2/15/2021, 05:42 PM",
+      "concept": "state changeerror",
+      "moodId": 1,
+      "instructorId": 1,
+      "entry": "another stae changed error",
+      "id": 14
+    },
+    {
+      "date": "2/15/2021, 05:44 PM",
+      "concept": "did you see it",
+      "moodId": 2,
+      "instructorId": 1,
+      "entry": "did you see it",
+      "id": 15
     }
   ],
   "moods": [

--- a/scripts/deleteBtn/deleteBtn.js
+++ b/scripts/deleteBtn/deleteBtn.js
@@ -1,10 +1,6 @@
 const eventHub = document.querySelector("main")
 
-export const deleteBnt = (id) => {
- return `
-  <button id="delete--${id}" class="deleteBtn">Delete</button>
- `
-}
+export const deleteBnt = ( id ) => `<button id="delete--${id}" class="deleteBtn">Delete</button>`
 
 eventHub.addEventListener("click", clickEvent => {
  if(clickEvent.target.id.includes("delete")) {

--- a/scripts/filter/FilterBar.js
+++ b/scripts/filter/FilterBar.js
@@ -1,5 +1,14 @@
 import { moodFilter } from "./moodFilter.js"
+import { getMoods, useMoods } from "../moods/MoodDataProvider.js"
+
 
 const contentTarget = document.querySelector(".filters")
 
-export const FilterBar = () => contentTarget.innerHTML = `${moodFilter()}`
+export const FilterBar = () => {
+  getMoods()
+    .then(() => {
+      const _moods = useMoods()
+     const fieldsetAndMoods =  moodFilter(_moods)
+     contentTarget.innerHTML = `${fieldsetAndMoods}`
+    });
+} // moodFilter

--- a/scripts/filter/moodFilter.js
+++ b/scripts/filter/moodFilter.js
@@ -1,38 +1,25 @@
-/*
- Get a copy of moods.
+import { getMoods, useMoods } from "../moods/MoodDataProvider.js"
 
-*/
 const eventHub = document.querySelector("main")
 
-const moods = [
-  {
-    id: 1,
-    label: "happy"
-  },
-  {
-    id: 2,
-    label: "sad"
-  },
-  {
-    id: 3,
-    label: "cold"
-  }
-]
-export const moodFilter = () => {
- const _moods = moods.map((mood) => {
+export const moodFilter = ( moodsCollection ) => {
+ const _moods = moodsCollection.map((mood) => {
   return `
     <input type="radio" name="moodFilter" id="${ mood.id }" value="${ mood.id }" />
     <label for="${ mood.id }" >${ mood.label }</label>
   `
  }).join("") // moods.map
- 
+
  return `
    <fieldset class="fieldset">
     <legend>Filter Entries by Mood</legend>
+    <input type="radio" name="moodFilter" id="0" value="0" />
+    <label for="0" >All</label>
     ${_moods}
    </fieldset>
  `
-}
+} // moodFilter
+
 
 eventHub.addEventListener("click", clickEvent => {
   if(clickEvent.target.name === "moodFilter") {

--- a/scripts/instructors/instructorSelector.js
+++ b/scripts/instructors/instructorSelector.js
@@ -1,7 +1,7 @@
 import { getInstructors, useInstructors } from "./instructorDataProvider.js"
 
 
-const _render = (instructorCollection) => {
+const _render = ( instructorCollection ) => {
  const contentTarget = document.querySelector("#instructorSelect")
  const instructors = instructorCollection.map((instructor) =>
   `<option value="${instructor.id}">${instructor.firstName} ${instructor.lastName}</option>`
@@ -9,7 +9,9 @@ const _render = (instructorCollection) => {
 
  contentTarget.innerHTML += `${instructors}`
 
-}
+} // _render
+
+
 export const instructorSelect = () => {
  getInstructors()
   .then(() => {

--- a/scripts/journalEntries/JournalDataProvider.js
+++ b/scripts/journalEntries/JournalDataProvider.js
@@ -5,7 +5,7 @@ export const useJournalEntries = () => journal.sort(_byDate)
 const journalStateChanged = new CustomEvent("journalStateChanged")
 const dispatchStateChangeEvent = () => eventHub.dispatchEvent(journalStateChanged)
 
-export const getEntries = () => {
+export const getJournalEntries = () => {
     /*
         Old way of entering mood.
         http://localhost:8088/entries
@@ -79,7 +79,7 @@ export const saveJournalEntry = ( entryObj ) => {
         },
         body: JSON.stringify(entryObj)
     })
-        .then(getEntries)
+        .then(getJournalEntries)
         .then(dispatchStateChangeEvent)
         // does calling dispatchStateChangeEvent
         // overwrite the CustomeEvent in eventHub or
@@ -93,7 +93,7 @@ eventHub.addEventListener("deleteBtnClicked", clickEvent => {
     fetch(_url, {
         method: "DELETE"
     })
-        .then(getEntries)
+        .then(getJournalEntries)
         .then(dispatchStateChangeEvent)
 }) // eventHub - deleteBtnClicked 
 

--- a/scripts/journalEntries/JournalEntryList.js
+++ b/scripts/journalEntries/JournalEntryList.js
@@ -4,28 +4,44 @@
  *    there are items in the collection exposed by the
  *    data provider component
  */
-import { getEntries, useJournalEntries } from "./JournalDataProvider.js"
+import { getJournalEntries, useJournalEntries } from "./JournalDataProvider.js"
 import { JournalEntryComponent } from "./JournalEntry.js"
 
-const contentTarget = document.querySelector(".main__article")
 const eventHub = document.querySelector("main")
 
-export const EntryListComponent = () => {
-    const entries = useJournalEntries()
+export const EntryListComponent = ( entriesCollection ) => {
     const entryLog = document.querySelector(".main__entries")
-
+    
     entryLog.innerHTML = `
         <h2>Journal Entries</h2>
         <ul id="entryLog" class="entries__log">
-            ${entries.map((entry) => JournalEntryComponent(entry)).join("")}
+            ${entriesCollection.map((entry) => JournalEntryComponent(entry)).join("")}
         </ul>
     `
 }
 
 eventHub.addEventListener("journalStateChanged", customEvent => {
- getEntries().then(() => EntryListComponent())
+ getJournalEntries().then(() => {
+     const _entries = useJournalEntries()
+     EntryListComponent(_entries)
+ })
 })
 
-eventHub.addEventListener("moodSelected", selectEvent => {
 
-}) // eventHub - moodSelected
+eventHub.addEventListener("moodSelected", selectEvent => {
+    getJournalEntries().then(() => {
+        const _entries = useJournalEntries()
+
+        const moodId = selectEvent.detail.moodId
+        const filterdMoodsById = _entries.filter((entryObj) => entryObj.moodId === moodId)
+
+        if(moodId) {
+            EntryListComponent(filterdMoodsById)
+        } else {
+            /*
+                Either user selected All or left selection as default, which is All.
+            */
+            EntryListComponent(_entries)
+        }
+    })
+})

--- a/scripts/journalEntries/JournalFormComponent.js
+++ b/scripts/journalEntries/JournalFormComponent.js
@@ -26,7 +26,7 @@ const _render = () => {
           
             <label for="moodSelect">Mood:</label>
             <select name="moodSelect" id="moodSelect">
-            <option value="0">--How am I feeling?--</option>
+              <option value="0">--How am I feeling?--</option>
             </select>
 
           <label for="journalEntry">Journal Entry</label>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,10 +1,12 @@
-import { getEntries } from "./journalEntries/JournalDataProvider.js";
+import { getJournalEntries, useJournalEntries } from "./journalEntries/JournalDataProvider.js";
 import { EntryListComponent } from "./journalEntries/JournalEntryList.js"
 import { JournalFormComponent } from "./journalEntries/JournalFormComponent.js"
 import { FilterBar } from "./filter/FilterBar.js"
 
-getEntries().then(() => {
+getJournalEntries()
+.then(() => {
+ const _entries = useJournalEntries()
  JournalFormComponent()
- EntryListComponent()
+ EntryListComponent(_entries)
  FilterBar()
 })

--- a/scripts/moods/MoodSelector.js
+++ b/scripts/moods/MoodSelector.js
@@ -5,7 +5,7 @@ const _render = (moodCollection) => {
  const options = moodCollection.map((mood) => `<option value="${mood.id}">${mood.label}</option>`).join("") // moodCollection.map
 
  contentTarget.innerHTML += `${options}`
-}
+} // _render
 
 export const MoodSelector = () => {
  getMoods()


### PR DESCRIPTION
# Description
Add radio buttons to filter notes by moon. If no mood is selected or the `All` option, all notes are displayed.

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# Testing Instructions

`git fetch --all`
`git checkout filter-by-mood`
`serve`

In another terminal where you db is located.

`json-server -p 8088 -w entires.json`

If filter/notes available, select radio button to filter entries by mood.

If no notes are available, create notes and select radio button to filter by mood.


# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings or errors
- [X] I have added test instructions that prove my fix is effective or that my feature works